### PR TITLE
Enforce owner check on uninit

### DIFF
--- a/programs/cardinal-token-manager/src/instructions/uninit.rs
+++ b/programs/cardinal-token-manager/src/instructions/uninit.rs
@@ -9,8 +9,7 @@ pub struct UninitCtx<'info> {
     #[account(mut, close = issuer, constraint = token_manager.state == TokenManagerState::Initialized as u8 @ ErrorCode::InvalidTokenManagerState)]
     token_manager: Box<Account<'info, TokenManager>>,
 
-    #[account(mut)]
-    // permissionlesss if you are the current token holder to prevent others from leaving token-manager initiailized
+    #[account(mut, constraint = issuer.key() == token_manager.issuer @ ErrorCode::InvalidIssuer)]
     issuer: Signer<'info>,
     #[account(mut, constraint =
         issuer_token_account.owner == issuer.key()

--- a/programs/cardinal-token-manager/src/instructions/uninit.rs
+++ b/programs/cardinal-token-manager/src/instructions/uninit.rs
@@ -10,9 +10,11 @@ pub struct UninitCtx<'info> {
     token_manager: Box<Account<'info, TokenManager>>,
 
     #[account(mut)]
+    // permissionlesss if you are the current token holder to prevent others from leaving token-manager initiailized
     issuer: Signer<'info>,
     #[account(mut, constraint =
-        issuer_token_account.mint == token_manager.mint
+        issuer_token_account.owner == issuer.key()
+        && issuer_token_account.mint == token_manager.mint
         && issuer_token_account.amount >= 1
         @ ErrorCode::InvalidIssuerTokenAccount
     )]


### PR DESCRIPTION
Previously not enforced to allow someone to trade the NFT and the new holder to uninit the token-manager

We have decided this functionality is not necessary at this time and better to be more explicit that only the issuer can uninit, and anyone can still re-init if they have the token